### PR TITLE
Support querying user reposts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This provides better type safety and flexibility when working with SoundCloud re
 - **`get_user_followings(identifier: &SoundcloudIdentifier, pagination: Option<&Paging>) -> Result<Users, Box<dyn Error>>`**
 - **`get_user_playlists(identifier: &SoundcloudIdentifier, pagination: Option<&Paging>) -> Result<Playlists, Box<dyn Error>>`**
 - **`get_user_tracks(identifier: &SoundcloudIdentifier, pagination: Option<&Paging>) -> Result<Tracks, Box<dyn Error>>`**
+- **`get_user_reposts(identifier: &SoundcloudIdentifier, pagination: Option<&Paging>) -> Result<Reposts, Box<dyn Error>>`**
 
 ## Notes on Downloads and FFmpeg
 - **HLS downloads** use `ffmpeg-sidecar`. On first HLS download, the crate will automatically download an FFmpeg binary for your platform. No manual installation is required.

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -74,8 +74,10 @@ impl Client {
         urn: &str,
         pagination: Option<&Paging>,
     ) -> Result<Reposts, Box<dyn Error>> {
-        let url = format!("stream/users/{}/reposts", urn);
-        let resp: Reposts = self.get(&url, pagination).await?;
-        Ok(resp)
+        let id = urn
+            .split(':')
+            .last()
+            .expect("Could not extract ID from URN");
+        return self.get_user_reposts_by_id(id, pagination).await;
     }
 }

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -1,7 +1,7 @@
 use crate::client::client::Client;
 use crate::models::client::SoundcloudIdentifier;
 use crate::models::query::{Paging, UsersQuery};
-use crate::models::response::{Playlists, Tracks, User, Users};
+use crate::models::response::{Playlists, Reposts, Tracks, User, Users};
 use std::error::Error;
 
 impl Client {
@@ -56,6 +56,25 @@ impl Client {
     ) -> Result<Tracks, Box<dyn Error>> {
         let url = format!("users/{identifier}/tracks");
         let resp: Tracks = self.get(&url, pagination).await?;
+        Ok(resp)
+    }
+    pub async fn get_user_reposts_by_id(
+        &self,
+        id: &str,
+        pagination: Option<&Paging>,
+    ) -> Result<Reposts, Box<dyn Error>> {
+        let url = format!("stream/users/{}/reposts", id);
+        let resp: Reposts = self.get(&url, pagination).await?;
+        Ok(resp)
+    }
+
+    pub async fn get_user_reposts_by_urn(
+        &self,
+        urn: &str,
+        pagination: Option<&Paging>,
+    ) -> Result<Reposts, Box<dyn Error>> {
+        let url = format!("stream/users/{}/reposts", urn);
+        let resp: Reposts = self.get(&url, pagination).await?;
         Ok(resp)
     }
 }

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -58,6 +58,7 @@ impl Client {
         let resp: Tracks = self.get(&url, pagination).await?;
         Ok(resp)
     }
+
     pub async fn get_user_reposts_by_id(
         &self,
         id: &str,

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -59,25 +59,21 @@ impl Client {
         Ok(resp)
     }
 
-    pub async fn get_user_reposts_by_id(
+    pub async fn get_user_reposts(
         &self,
-        id: &str,
+        identifier: &SoundcloudIdentifier,
         pagination: Option<&Paging>,
     ) -> Result<Reposts, Box<dyn Error>> {
+        let id = match identifier {
+            SoundcloudIdentifier::Id(id) => id.to_string(),
+            SoundcloudIdentifier::Urn(urn) => urn
+                .split(':')
+                .last()
+                .expect("Could not extract ID from URN")
+                .to_owned(),
+        };
         let url = format!("stream/users/{}/reposts", id);
         let resp: Reposts = self.get(&url, pagination).await?;
         Ok(resp)
-    }
-
-    pub async fn get_user_reposts_by_urn(
-        &self,
-        urn: &str,
-        pagination: Option<&Paging>,
-    ) -> Result<Reposts, Box<dyn Error>> {
-        let id = urn
-            .split(':')
-            .last()
-            .expect("Could not extract ID from URN");
-        return self.get_user_reposts_by_id(id, pagination).await;
     }
 }

--- a/src/models/response/mod.rs
+++ b/src/models/response/mod.rs
@@ -1,8 +1,10 @@
 mod playlists;
+mod reposts;
 mod search;
 mod tracks;
 mod users;
 pub use playlists::*;
+pub use reposts::*;
 pub use search::*;
 pub use tracks::*;
 pub use users::*;

--- a/src/models/response/reposts.rs
+++ b/src/models/response/reposts.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::response::{PagingCollection, users::UserSummary},
+    response::{Track, User},
+};
+
+pub type Reposts = PagingCollection<Repost>;
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct Repost {
+    pub created_at: Option<String>,
+    pub r#type: Option<String>,
+    pub user: Option<User>,
+    pub uuid: Option<String>,
+    pub caption: Option<String>,
+    pub track: Option<Track>,
+}

--- a/src/models/response/reposts.rs
+++ b/src/models/response/reposts.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    models::response::{PagingCollection, users::UserSummary},
+    models::response::PagingCollection,
     response::{Track, User},
 };
 


### PR DESCRIPTION
Implements #1

I don't know if the endpoint is official? It's https://api-v2.soundcloud.com/stream/users/<id>/reposts if you were wondering. Anyways I added the response type from what I could see. It might be missing some fields as I didn't look online, I just looked at some examples. Seems to work on my machine ;) It doesn't seem to support urn, so I just converted it and called the id method. Feel free to decline the PR if you want to keep all the endpoints pure, I'm happy to keep using my branch :)

Thanks again for the fantastic library <3
